### PR TITLE
attempts to fix API allowing mismatching passwords on signup

### DIFF
--- a/app/controllers/users.js
+++ b/app/controllers/users.js
@@ -45,16 +45,24 @@ const makeErrorHandler = (res, next) =>
     next(error);
 
 const signup = (req, res, next) => {
-  let credentials = req.body.credentials;
-  let user = { email: credentials.email, password: credentials.password };
+  const credentials = req.body.credentials
+  const user = { email: credentials.email, password: credentials.password, confirmPassword: credentials.password_confirmation }
   getToken()
-    .then(token => user.token = token)
+    .then(token => {
+      user.token = token
+      return user
+    })
+    .then((user) => {
+      if (user.password !== user.confirmPassword) {
+        return Promise.reject(new HttpError(400))
+      }
+    })
     .then(() =>
       new User(user).save())
     .then(user =>
       res.status(201).json({ user }))
-    .catch(makeErrorHandler(res, next));
-};
+    .catch(makeErrorHandler(res, next))
+}
 
 const signin = (req, res, next) => {
   let credentials = req.body.credentials;


### PR DESCRIPTION
attempts to fix the issue located on team-project #https://github.com/ga-wdi-boston/team-project/issues/276. Description of issue and fix are located there. 

pulls the confirm_password property out of credentials and stuck it in
the user object as well. then added a step in the signup promise chain
to check to make sure that the user.password and the user.confirmPassword
are the same. if not reject the promise.